### PR TITLE
KAF-4: Add support for remaining C* and DSE datatypes except Counter and DateRange

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,3 +5,4 @@
 KAF-1: Support JSON Records
 KAF-2: Replace duped dsbulk commons code with a ref to the new dsbulk-commons-1.2.0-ng
 KAF-3: Expand Kafka Struct support to handle complex objects
+KAF-4: Add support for remaining C* and DSE datatypes except Counter and DateRange


### PR DESCRIPTION
* Add tests for geospatial types
* Don't bother testing remaining C* types because Kafka records will only
  have string or numeric values for these types, and converting from
  such primitives to C* types is well-established/tested in ExtendedCodecRegistry.