### PR TITLE
KAF-7: Support mapping raw values in records (e.g. mycol=value or mycol=key)

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,3 +8,4 @@
 - [new feature] KAF-4: Add support for remaining C* and DSE datatypes except Counter and DateRange
 - [new feature] KAF-6: Support specifying TTL for inserted rows
 - [new feature] KAF-25: Set timestamp on DSE row to the timestamp in the Kafka record
+- [improvement] KAF-7: Support mapping raw values in records (e.g. mycol=value or mycol=key)

--- a/src/main/java/com/datastax/kafkaconnector/DseSinkConfig.java
+++ b/src/main/java/com/datastax/kafkaconnector/DseSinkConfig.java
@@ -256,6 +256,15 @@ public class DseSinkConfig extends AbstractConfig {
       if (mapping.containsKey(column)) {
         errors.add(String.format("Mapping already defined for column '%s'", column.asInternal()));
       }
+      String fieldString = field.asInternal();
+      if (fieldString.equals("value") || fieldString.equals("key")) {
+        field = CqlIdentifier.fromInternal(fieldString + '.' + RawRecord.FIELD_NAME);
+      } else if (!fieldString.startsWith("key.") && !fieldString.startsWith("value.")) {
+        errors.add(
+            String.format(
+                "Invalid field name '%s': field names in mapping must be 'key', 'value', or start with 'key.' or 'value.'.",
+                fieldString));
+      }
       mapping.put(column, field);
       return null;
     }

--- a/src/main/java/com/datastax/kafkaconnector/DseSinkConnector.java
+++ b/src/main/java/com/datastax/kafkaconnector/DseSinkConnector.java
@@ -58,7 +58,8 @@ import org.slf4j.LoggerFactory;
 public class DseSinkConnector extends SinkConnector {
   static final String MAPPING_OPT = "mapping";
   static final RecordMetadata JSON_RECORD_METADATA =
-      (field, cqlType) -> GenericType.of(JsonNode.class);
+      (field, cqlType) ->
+          field.equals(RawRecord.FIELD_NAME) ? GenericType.STRING : GenericType.of(JsonNode.class);
   static final ObjectMapper objectMapper = new ObjectMapper();
   static final JavaType jsonNodeMapType =
       objectMapper.constructType(new TypeReference<Map<String, JsonNode>>() {}.getType());

--- a/src/main/java/com/datastax/kafkaconnector/JsonData.java
+++ b/src/main/java/com/datastax/kafkaconnector/JsonData.java
@@ -16,13 +16,17 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class JsonData implements Record {
   private final Map<String, JsonNode> data;
+  private final String json;
+  private final Set<String> fields;
 
   JsonData(ObjectMapper objectMapper, JavaType jsonNodeMapType, String json) throws IOException {
+    this.json = json;
     JsonFactory factory = objectMapper.getFactory();
     if (json == null) {
       data = Collections.emptyMap();
@@ -37,15 +41,20 @@ public class JsonData implements Record {
         }
       }
     }
+    fields = new HashSet<>(data.keySet());
+    fields.add(RawRecord.FIELD_NAME);
   }
 
   @Override
   public Set<String> fields() {
-    return data.keySet();
+    return fields;
   }
 
   @Override
   public Object getFieldValue(String field) {
+    if (field.equals(RawRecord.FIELD_NAME)) {
+      return json;
+    }
     return data.get(field);
   }
 }

--- a/src/main/java/com/datastax/kafkaconnector/RawRecord.java
+++ b/src/main/java/com/datastax/kafkaconnector/RawRecord.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * This software is subject to the below license agreement.
+ * DataStax may make changes to the agreement from time to time,
+ * and will post the amended terms at
+ * https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
+ */
+package com.datastax.kafkaconnector;
+
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import java.util.HashSet;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+
+public class RawRecord implements Record, RecordMetadata {
+  static final String FIELD_NAME = "__self";
+  private static final Set<String> FIELDS = new HashSet<>();
+
+  static {
+    FIELDS.add(FIELD_NAME);
+  }
+
+  private final GenericType<?> type;
+  private final Object value;
+
+  RawRecord(@NotNull Object keyOrValue) {
+    value = keyOrValue;
+    type = GenericType.of(keyOrValue.getClass());
+  }
+
+  @Override
+  public GenericType<?> getFieldType(@NotNull String field, @NotNull DataType cqlType) {
+    return type;
+  }
+
+  @Override
+  public Set<String> fields() {
+    return FIELDS;
+  }
+
+  @Override
+  public Object getFieldValue(String field) {
+    return value;
+  }
+}

--- a/src/main/java/com/datastax/kafkaconnector/RecordMapper.java
+++ b/src/main/java/com/datastax/kafkaconnector/RecordMapper.java
@@ -66,9 +66,9 @@ public class RecordMapper {
       Collection<CqlIdentifier> columns = mapping.fieldToColumns(CqlIdentifier.fromInternal(field));
       if ((columns == null || columns.isEmpty()) && !allowExtraFields) {
         throw new ConfigException(
-            "Extraneous field "
-                + field
-                + " was found in record. "
+            "Extraneous field '"
+                + getExternalName(field)
+                + "' was found in record. "
                 + "Please declare it explicitly in the mapping.");
       }
       if (columns != null) {
@@ -87,6 +87,13 @@ public class RecordMapper {
     BoundStatement bs = builder.build();
     ensurePartitionKeySet(bs);
     return bs;
+  }
+
+  private static String getExternalName(String field) {
+    if (field.endsWith(RawRecord.FIELD_NAME)) {
+      return field.substring(0, field.length() - RawRecord.FIELD_NAME.length() - 1);
+    }
+    return field;
   }
 
   private <T> void bindColumn(
@@ -142,9 +149,9 @@ public class RecordMapper {
       CqlIdentifier field = mapping.columnToField(variable);
       if (!recordFields.contains(field.asInternal())) {
         throw new ConfigException(
-            "Required field "
-                + field
-                + " (mapped to column "
+            "Required field '"
+                + getExternalName(field.asInternal())
+                + "' (mapped to column "
                 + variable.asCql(true)
                 + ") was missing from record. "
                 + "Please remove it from the mapping.");

--- a/src/main/java/com/datastax/kafkaconnector/StructData.java
+++ b/src/main/java/com/datastax/kafkaconnector/StructData.java
@@ -10,6 +10,7 @@ package com.datastax.kafkaconnector;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Field;
@@ -23,10 +24,13 @@ public class StructData implements Record {
 
   StructData(@Nullable Struct struct) {
     this.struct = struct;
-    fields =
-        struct == null
-            ? Collections.emptySet()
-            : struct.schema().fields().stream().map(Field::name).collect(Collectors.toSet());
+    if (struct == null) {
+      fields = Collections.singleton(RawRecord.FIELD_NAME);
+    } else {
+      fields = new HashSet<>();
+      fields.add(RawRecord.FIELD_NAME);
+      fields.addAll(struct.schema().fields().stream().map(Field::name).collect(Collectors.toSet()));
+    }
   }
 
   @Override
@@ -36,6 +40,10 @@ public class StructData implements Record {
 
   @Override
   public Object getFieldValue(String field) {
+    if (field.equals(RawRecord.FIELD_NAME)) {
+      return struct;
+    }
+
     if (struct == null) {
       return null;
     }

--- a/src/main/java/com/datastax/kafkaconnector/StructRecordMetadata.java
+++ b/src/main/java/com/datastax/kafkaconnector/StructRecordMetadata.java
@@ -36,6 +36,9 @@ public class StructRecordMetadata implements RecordMetadata {
 
   @Override
   public GenericType<?> getFieldType(@NotNull String field, @NotNull DataType cqlType) {
+    if (field.equals(RawRecord.FIELD_NAME)) {
+      return GenericType.of(Struct.class);
+    }
     Schema fieldType = schema.field(field).schema();
     return getGenericType(fieldType);
   }

--- a/src/test/java/com/datastax/kafkaconnector/DseSinkConnectorTest.java
+++ b/src/test/java/com/datastax/kafkaconnector/DseSinkConnectorTest.java
@@ -92,7 +92,7 @@ class DseSinkConnectorTest {
     assertThatThrownBy(
             () ->
                 DseSinkConnector.validateKeyspaceAndTable(
-                    session, makeConfig("MyKs", "t1", "c1=f1")))
+                    session, makeConfig("MyKs", "t1", "c1=value.f1")))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining(
             "Keyspace does not exist, however a keyspace myks was found. Update the config to use myks if desired.");
@@ -106,7 +106,7 @@ class DseSinkConnectorTest {
     assertThatThrownBy(
             () ->
                 DseSinkConnector.validateKeyspaceAndTable(
-                    session, makeConfig("ks1", "MyTable", "c1=f1")))
+                    session, makeConfig("ks1", "MyTable", "c1=value.f1")))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining(
             "Table does not exist, however a table mytable was found. Update the config to use mytable if desired.");
@@ -119,7 +119,7 @@ class DseSinkConnectorTest {
     assertThatThrownBy(
             () ->
                 DseSinkConnector.validateKeyspaceAndTable(
-                    session, makeConfig("MyKs", "t1", "c1=f1")))
+                    session, makeConfig("MyKs", "t1", "c1=value.f1")))
         .isInstanceOf(ConfigException.class)
         .hasMessage("Invalid value \"MyKs\" for configuration keyspace: Not found");
   }
@@ -132,14 +132,14 @@ class DseSinkConnectorTest {
     assertThatThrownBy(
             () ->
                 DseSinkConnector.validateKeyspaceAndTable(
-                    session, makeConfig("ks1", "MyTable", "c1=f1")))
+                    session, makeConfig("ks1", "MyTable", "c1=value.f1")))
         .isInstanceOf(ConfigException.class)
         .hasMessage("Invalid value \"MyTable\" for configuration table: Not found");
   }
 
   @Test
   void should_error_when_mapping_does_not_use_primary_key_columns() {
-    DseSinkConfig config = makeConfig("myks", "mytable", C3 + "=f3");
+    DseSinkConfig config = makeConfig("myks", "mytable", C3 + "=key.f3");
     assertThatThrownBy(() -> DseSinkConnector.validateMappingColumns(session, config))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining("but are not mapped: " + C1);
@@ -147,7 +147,7 @@ class DseSinkConnectorTest {
 
   @Test
   void should_error_when_mapping_has_nonexistent_column() {
-    DseSinkConfig config = makeConfig("myks", "mytable", "nocol=f3");
+    DseSinkConfig config = makeConfig("myks", "mytable", "nocol=key.f3");
     assertThatThrownBy(() -> DseSinkConnector.validateMappingColumns(session, config))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining("do not exist in table mytable: nocol");
@@ -156,7 +156,8 @@ class DseSinkConnectorTest {
   @Test
   void should_make_correct_insert_cql() {
     DseSinkConfig config =
-        makeConfig("myks", "mytable", String.format("%s=f1, \"%s\"=f2, %s=f3", C1, C2, C3));
+        makeConfig(
+            "myks", "mytable", String.format("%s=key.f1, \"%s\"=key.f2, %s=key.f3", C1, C2, C3));
     assertThat(DseSinkConnector.makeInsertStatement(config))
         .isEqualTo(
             String.format(
@@ -167,7 +168,11 @@ class DseSinkConnectorTest {
   @Test
   void should_make_correct_insert_cql_with_ttl() {
     DseSinkConfig config =
-        makeConfig("myks", "mytable", String.format("%s=f1, \"%s\"=f2, %s=f3", C1, C2, C3), 1234);
+        makeConfig(
+            "myks",
+            "mytable",
+            String.format("%s=key.f1, \"%s\"=key.f2, %s=key.f3", C1, C2, C3),
+            1234);
     assertThat(DseSinkConnector.makeInsertStatement(config))
         .isEqualTo(
             String.format(

--- a/src/test/java/com/datastax/kafkaconnector/JsonDataTest.java
+++ b/src/test/java/com/datastax/kafkaconnector/JsonDataTest.java
@@ -29,7 +29,7 @@ class JsonDataTest {
     JavaType type = mapper.constructType(new TypeReference<Map<String, JsonNode>>() {}.getType());
     JsonData jsonData =
         new JsonData(mapper, type, "{\"f1\": 42, \"f2\": {\"sub1\": 37, \"sub2\": 96}}");
-    assertThat(jsonData.fields()).containsOnly("f1", "f2");
+    assertThat(jsonData.fields()).containsOnly(RawRecord.FIELD_NAME, "f1", "f2");
     assertThat(jsonData.getFieldValue("f1")).isEqualTo(new IntNode(42));
     Object f2 = jsonData.getFieldValue("f2");
 
@@ -46,7 +46,7 @@ class JsonDataTest {
     ObjectMapper mapper = new ObjectMapper();
     JavaType type = mapper.constructType(new TypeReference<Map<String, JsonNode>>() {}.getType());
     JsonData jsonData = new JsonData(mapper, type, "{}");
-    assertThat(jsonData.fields()).isEmpty();
+    assertThat(jsonData.fields()).containsOnly(RawRecord.FIELD_NAME);
     assertThat(jsonData.getFieldValue("noexist")).isEqualTo(null);
   }
 }

--- a/src/test/java/com/datastax/kafkaconnector/RecordMapperTest.java
+++ b/src/test/java/com/datastax/kafkaconnector/RecordMapperTest.java
@@ -391,7 +391,31 @@ class RecordMapperTest {
     assertThatThrownBy(() -> mapper.map(record))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining(
-            "Extraneous field field3 was found in record. "
+            "Extraneous field 'field3' was found in record. "
+                + "Please declare it explicitly in the mapping.");
+  }
+
+  @Test
+  void should_return_unmappable_statement_when_extra_field_key() {
+    when(record.fields()).thenReturn(set(F1, F2, F3, "key.__self"));
+    RecordMapper mapper =
+        new RecordMapper(insertStatement, mapping, recordMetadata, false, false, false);
+    assertThatThrownBy(() -> mapper.map(record))
+        .isInstanceOf(ConfigException.class)
+        .hasMessageContaining(
+            "Extraneous field 'key' was found in record. "
+                + "Please declare it explicitly in the mapping.");
+  }
+
+  @Test
+  void should_return_unmappable_statement_when_extra_field_value() {
+    when(record.fields()).thenReturn(set(F1, F2, F3, "value.__self"));
+    RecordMapper mapper =
+        new RecordMapper(insertStatement, mapping, recordMetadata, false, false, false);
+    assertThatThrownBy(() -> mapper.map(record))
+        .isInstanceOf(ConfigException.class)
+        .hasMessageContaining(
+            "Extraneous field 'value' was found in record. "
                 + "Please declare it explicitly in the mapping.");
   }
 
@@ -403,7 +427,35 @@ class RecordMapperTest {
     assertThatThrownBy(() -> mapper.map(record))
         .isInstanceOf(ConfigException.class)
         .hasMessageContaining(
-            "Required field field3 (mapped to column \"My Fancy Column Name\") was missing from record. "
+            "Required field 'field3' (mapped to column \"My Fancy Column Name\") was missing from record. "
+                + "Please remove it from the mapping.");
+  }
+
+  @Test
+  void should_return_unmappable_statement_when_missing_field_key() {
+    when(mapping.fieldToColumns(CqlIdentifier.fromInternal("key.__self")))
+        .thenReturn(Collections.singleton(C1));
+    when(mapping.columnToField(C1)).thenReturn(CqlIdentifier.fromInternal("key.__self"));
+    RecordMapper mapper =
+        new RecordMapper(insertStatement, mapping, recordMetadata, false, true, false);
+    assertThatThrownBy(() -> mapper.map(record))
+        .isInstanceOf(ConfigException.class)
+        .hasMessageContaining(
+            "Required field 'key' (mapped to column col1) was missing from record. "
+                + "Please remove it from the mapping.");
+  }
+
+  @Test
+  void should_return_unmappable_statement_when_missing_field_value() {
+    when(mapping.fieldToColumns(CqlIdentifier.fromInternal("value.__self")))
+        .thenReturn(Collections.singleton(C1));
+    when(mapping.columnToField(C1)).thenReturn(CqlIdentifier.fromInternal("value.__self"));
+    RecordMapper mapper =
+        new RecordMapper(insertStatement, mapping, recordMetadata, false, true, false);
+    assertThatThrownBy(() -> mapper.map(record))
+        .isInstanceOf(ConfigException.class)
+        .hasMessageContaining(
+            "Required field 'value' (mapped to column col1) was missing from record. "
                 + "Please remove it from the mapping.");
   }
 

--- a/src/test/java/com/datastax/kafkaconnector/StructDataTest.java
+++ b/src/test/java/com/datastax/kafkaconnector/StructDataTest.java
@@ -31,7 +31,8 @@ class StructDataTest {
 
   @Test
   void should_parse_field_names_from_struct() {
-    assertThat(structData.fields()).containsExactlyInAnyOrder("bigint", "boolean", "bytes");
+    assertThat(structData.fields())
+        .containsExactlyInAnyOrder(RawRecord.FIELD_NAME, "bigint", "boolean", "bytes");
   }
 
   @Test
@@ -48,7 +49,7 @@ class StructDataTest {
   @Test
   void should_handle_null_struct() {
     StructData empty = new StructData(null);
-    assertThat(empty.fields()).isEmpty();
+    assertThat(empty.fields()).containsOnly(RawRecord.FIELD_NAME);
     assertThat(empty.getFieldValue("junk")).isNull();
   }
 }


### PR DESCRIPTION
* Add RawRecord class
* Update JsonData and StructData to provide a pseudo-field called "__self" to return the raw object
* Add validation logic to ensure that mappings only refer to "key", "key.<something>", "value", "value.something" fields.