### PR TITLE
KAF-26: Support configurable time-zone and locale for date/time parsing

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -12,3 +12,4 @@
 - [improvement] KAF-12: Fix setting names to conform to design doc
 - [improvement] KAF-8: Use batch requests to load data
 - [improvement] KAF-27: Produce a tarball deliverable in build process
+- [improvement] KAF-26: Support configurable time-zone and locale for date/time parsing

--- a/conf/dse-sink.properties.sample
+++ b/conf/dse-sink.properties.sample
@@ -6,13 +6,48 @@ tasks.max=1
 topics=my_topic
 
 # Local datacenter name
-loadBalancing.localDc=Cassandra
+#loadBalancing.localDc=Cassandra
 
 # Initial DSE contact points
-contactPoints=[127.0.0.1]
+#contactPoints=[127.0.0.1]
 
 # Port to connect to on DSE nodes
-port=9042
+#port=9042
+
+# Locale to use for locale-sensitive conversions.
+#codec.locale=en_US
+
+# The time zone to use for temporal conversions that do not convey any explicit time zone
+# information.
+#codec.timeZone=UTC
+
+# The temporal pattern to use for `String` to CQL `timestamp` conversion. Valid choices:
+#
+# - A date-time pattern such as `yyyy-MM-dd HH:mm:ss`.
+# - A pre-defined formatter such as `ISO_ZONED_DATE_TIME` or `ISO_INSTANT`. Any public static
+#   field in `java.time.format.DateTimeFormatter` can be used.
+# - The special formatter `CQL_TIMESTAMP`, which is a special parser that accepts all valid CQL
+#   literal formats for the `timestamp` type.
+#codec.timestamp=CQL_TIMESTAMP
+
+# The temporal pattern to use for `String` to CQL `date` conversion. Valid choices:
+#
+# - A date-time pattern such as `yyyy-MM-dd`.
+# - A pre-defined formatter such as `ISO_LOCAL_DATE`. Any public static field in
+#   `java.time.format.DateTimeFormatter` can be used.
+#codec.date=ISO_LOCAL_DATE
+
+# The temporal pattern to use for `String` to CQL `time` conversion. Valid choices:
+#
+# - A date-time pattern, such as `HH:mm:ss`.
+# - A pre-defined formatter, such as `ISO_LOCAL_TIME`. Any public static field in
+#   `java.time.format.DateTimeFormatter` can be used.
+#codec.time=ISO_LOCAL_TIME
+
+# If the input is a string containing only digits that cannot be parsed using the
+# `codec.timestamp` format, the specified time unit is applied to the parsed value. All
+# `TimeUnit` enum constants are valid choices.
+#codec.unit=MILLISECONDS
 
 ### Settings for topic my_topic ###
 

--- a/src/main/java/com/datastax/kafkaconnector/DseSinkConnector.java
+++ b/src/main/java/com/datastax/kafkaconnector/DseSinkConnector.java
@@ -280,7 +280,9 @@ public class DseSinkConnector extends SinkConnector {
 
     Config dsbulkConfig = ConfigFactory.load().getConfig("dsbulk");
     CodecSettings codecSettings =
-        new CodecSettings(new DefaultLoaderConfig(dsbulkConfig.getConfig("codec")));
+        new CodecSettings(
+            new DefaultLoaderConfig(config.getConfigOverrides())
+                .withFallback(dsbulkConfig.getConfig("codec")));
     codecSettings.init();
 
     if (configLoader != null) {

--- a/src/main/java/com/datastax/kafkaconnector/config/DseSinkConfig.java
+++ b/src/main/java/com/datastax/kafkaconnector/config/DseSinkConfig.java
@@ -10,6 +10,9 @@ package com.datastax.kafkaconnector.config;
 
 import com.datastax.kafkaconnector.util.StringUtil;
 import com.google.common.base.Splitter;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,11 +25,17 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 /** Connector configuration and validation. */
+@SuppressWarnings("WeakerAccess")
 public class DseSinkConfig {
   static final String CONTACT_POINTS_OPT = "contactPoints";
   static final String PORT_OPT = "port";
   static final String DC_OPT = "loadBalancing.localDc";
-  private static final Pattern TOPIC_PAT = Pattern.compile("topic\\.([^.]+)");
+  static final String LOCALE_OPT = "codec.locale";
+  static final String TIMEZONE_OPT = "codec.timeZone";
+  static final String TIMESTAMP_PAT_OPT = "codec.timestamp";
+  static final String DATE_PAT_OPT = "codec.date";
+  static final String TIME_PAT_OPT = "codec.time";
+  static final String TIME_UNIT_OPT = "codec.unit";
   public static final ConfigDef GLOBAL_CONFIG_DEF =
       new ConfigDef()
           .define(
@@ -47,7 +56,44 @@ public class DseSinkConfig {
               ConfigDef.Type.STRING,
               "",
               ConfigDef.Importance.HIGH,
-              "The datacenter name (commonly dc1, dc2, etc.) local to the machine on which the connector is running.");
+              "The datacenter name (commonly dc1, dc2, etc.) local to the machine on which the connector is running")
+          .define(
+              LOCALE_OPT,
+              ConfigDef.Type.STRING,
+              "en_US",
+              ConfigDef.Importance.HIGH,
+              "The locale to use for locale-sensitive conversions.")
+          .define(
+              TIMEZONE_OPT,
+              ConfigDef.Type.STRING,
+              "UTC",
+              ConfigDef.Importance.HIGH,
+              "The time zone to use for temporal conversions that do not convey any explicit time zone information")
+          .define(
+              TIMESTAMP_PAT_OPT,
+              ConfigDef.Type.STRING,
+              "CQL_TIMESTAMP",
+              ConfigDef.Importance.HIGH,
+              "The temporal pattern to use for `String` to CQL `timestamp` conversion")
+          .define(
+              DATE_PAT_OPT,
+              ConfigDef.Type.STRING,
+              "ISO_LOCAL_DATE",
+              ConfigDef.Importance.HIGH,
+              "The temporal pattern to use for `String` to CQL `date` conversion")
+          .define(
+              TIME_PAT_OPT,
+              ConfigDef.Type.STRING,
+              "ISO_LOCAL_TIME",
+              ConfigDef.Importance.HIGH,
+              "The temporal pattern to use for `String` to CQL `time` conversion")
+          .define(
+              TIME_UNIT_OPT,
+              ConfigDef.Type.STRING,
+              "MILLISECONDS",
+              ConfigDef.Importance.HIGH,
+              "If the input is a string containing only digits that cannot be parsed using the `codec.timestamp` format, the specified time unit is applied to the parsed value. All `TimeUnit` enum constants are valid choices.");
+  private static final Pattern TOPIC_PAT = Pattern.compile("topic\\.([^.]+)");
   private final AbstractConfig globalConfig;
   private final Map<String, TopicConfig> topicConfigs;
 
@@ -117,6 +163,20 @@ public class DseSinkConfig {
 
   public Map<String, TopicConfig> getTopicConfigs() {
     return topicConfigs;
+  }
+
+  public Config getConfigOverrides() {
+    String[] settingNames = {
+      LOCALE_OPT, TIMEZONE_OPT, TIMESTAMP_PAT_OPT, DATE_PAT_OPT, TIME_PAT_OPT, TIME_UNIT_OPT
+    };
+    String config =
+        Arrays.stream(settingNames)
+            .map(
+                s ->
+                    String.format(
+                        "%s=\"%s\"", s.substring("codec.".length()), globalConfig.getString(s)))
+            .collect(Collectors.joining("\n"));
+    return ConfigFactory.parseString(config);
   }
 
   @Override

--- a/src/test/java/com/datastax/kafkaconnector/config/DseSinkConfigTest.java
+++ b/src/test/java/com/datastax/kafkaconnector/config/DseSinkConfigTest.java
@@ -11,6 +11,7 @@ package com.datastax.kafkaconnector.config;
 import static com.datastax.kafkaconnector.config.DseSinkConfig.CONTACT_POINTS_OPT;
 import static com.datastax.kafkaconnector.config.DseSinkConfig.DC_OPT;
 import static com.datastax.kafkaconnector.config.DseSinkConfig.PORT_OPT;
+import static com.datastax.kafkaconnector.config.DseSinkConfig.TIME_PAT_OPT;
 import static com.datastax.kafkaconnector.config.TopicConfig.KEYSPACE_OPT;
 import static com.datastax.kafkaconnector.config.TopicConfig.MAPPING_OPT;
 import static com.datastax.kafkaconnector.config.TopicConfig.TABLE_OPT;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.Test;
@@ -65,6 +67,25 @@ class DseSinkConfigTest {
     DseSinkConfig d = new DseSinkConfig(props);
     assertThat(d.getContactPoints()).containsExactly("127.0.0.1", "127.0.1.1");
     assertThat(d.getLocalDc()).isEqualTo("local");
+  }
+
+  @Test
+  void should_produce_config_overrides() {
+    Map<String, String> props =
+        ImmutableMap.<String, String>builder()
+            .put(CONTACT_POINTS_OPT, "127.0.0.1, 127.0.1.1")
+            .put(DC_OPT, "local")
+            .put(TIME_PAT_OPT, "foo")
+            .build();
+
+    DseSinkConfig d = new DseSinkConfig(props);
+    Config configOverrides = d.getConfigOverrides();
+    assertThat(configOverrides.getString("locale")).isEqualTo("en_US");
+    assertThat(configOverrides.getString("timeZone")).isEqualTo("UTC");
+    assertThat(configOverrides.getString("timestamp")).isEqualTo("CQL_TIMESTAMP");
+    assertThat(configOverrides.getString("date")).isEqualTo("ISO_LOCAL_DATE");
+    assertThat(configOverrides.getString("time")).isEqualTo("foo");
+    assertThat(configOverrides.getString("unit")).isEqualTo("MILLISECONDS");
   }
 
   @Test


### PR DESCRIPTION
* Also change udt field in integration test to be frozen, for compatibility with DSE 5.0.