### PR TITLE
KAF-30: Connector throws "event executor terminated" with multiple workers in distributed mode

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -17,3 +17,4 @@
 - [improvement] KAF-29: Date/Time conversion settings should be topic-scoped
 - [improvement] KAF-13: Exclude unnecessary classes from uberjar
 - [new feature] KAF-9: Support specifying consistency level for statements
+- [bug] KAF-30: Connector throws "event executor terminated" with multiple workers in distributed mode

--- a/src/main/java/com/datastax/kafkaconnector/InstanceState.java
+++ b/src/main/java/com/datastax/kafkaconnector/InstanceState.java
@@ -13,7 +13,9 @@ import com.datastax.kafkaconnector.codecs.KafkaCodecRegistry;
 import com.datastax.kafkaconnector.config.DseSinkConfig;
 import com.datastax.kafkaconnector.config.TopicConfig;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.google.common.collect.Sets;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import org.apache.kafka.common.KafkaException;
 import org.jetbrains.annotations.NotNull;
@@ -24,6 +26,7 @@ class InstanceState {
   private final DseSinkConfig config;
   private final Map<String, TopicState> topicStates;
   private final Semaphore requestBarrier;
+  private final Set<DseSinkTask> tasks;
 
   InstanceState(
       @NotNull DseSinkConfig config,
@@ -33,6 +36,19 @@ class InstanceState {
     this.config = config;
     this.topicStates = topicStates;
     this.requestBarrier = new Semaphore(getConfig().getMaxConcurrentRequests());
+    tasks = Sets.newConcurrentHashSet();
+  }
+
+  void registerTask(DseSinkTask task) {
+    tasks.add(task);
+  }
+
+  void unregisterTask(DseSinkTask task) {
+    tasks.remove(task);
+  }
+
+  Set<DseSinkTask> getTasks() {
+    return tasks;
   }
 
   @NotNull


### PR DESCRIPTION
* Add various synchronization constructs to enable the connector
  shutdown to wait for tasks to stop.
* Reset instance state when connector is stopped, to enable a clean
  startup if start is later invoked.