### PR TITLE
KAF-13: Exclude unnecessary classes from uberjar

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,3 +19,4 @@
 - [new feature] KAF-9: Support specifying consistency level for statements
 - [bug] KAF-30: Connector throws "event executor terminated" with multiple workers in distributed mode
 - [improvement] KAF-31: Support DSE DateRange Type
+- [improvement] KAF-13: Exclude unnecessary classes from uberjar

--- a/pom.xml
+++ b/pom.xml
@@ -363,11 +363,33 @@ https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
               <goal>shade</goal>
             </goals>
             <configuration>
+              <minimizeJar>true</minimizeJar>
               <artifactSet>
                 <excludes>
                   <exclude>org.apache.kafka:*</exclude>
+                  <exclude>org.assertj:*</exclude>
+                  <exclude>org.mockito:*</exclude>
+                  <exclude>org.checkerframework:*</exclude>
+                  <exclude>org.junit.jupiter:*</exclude>
+                  <exclude>org.junit.platform:*</exclude>
+                  <exclude>org.opentest4j:*</exclude>
+                  <exclude>com.datastax.oss.simulacron:*</exclude>
                 </excludes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>com.datastax.oss:java-driver-core</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>com.datastax.dse:dse-java-driver-core</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer
                     implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/src/it/java/com/datastax/kafkaconnector/simulacron/SimpleEndToEndSimulacronIT.java
+++ b/src/it/java/com/datastax/kafkaconnector/simulacron/SimpleEndToEndSimulacronIT.java
@@ -8,6 +8,8 @@
  */
 package com.datastax.kafkaconnector.simulacron;
 
+import static com.datastax.dsbulk.commons.tests.logging.StreamType.STDERR;
+import static com.datastax.dsbulk.commons.tests.logging.StreamType.STDOUT;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.serverError;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
@@ -22,6 +24,9 @@ import ch.qos.logback.core.joran.spi.JoranException;
 import com.datastax.dsbulk.commons.tests.logging.LogCapture;
 import com.datastax.dsbulk.commons.tests.logging.LogInterceptingExtension;
 import com.datastax.dsbulk.commons.tests.logging.LogInterceptor;
+import com.datastax.dsbulk.commons.tests.logging.StreamCapture;
+import com.datastax.dsbulk.commons.tests.logging.StreamInterceptingExtension;
+import com.datastax.dsbulk.commons.tests.logging.StreamInterceptor;
 import com.datastax.dsbulk.commons.tests.simulacron.SimulacronExtension;
 import com.datastax.dsbulk.commons.tests.simulacron.SimulacronUtils;
 import com.datastax.dsbulk.commons.tests.simulacron.SimulacronUtils.Column;
@@ -60,6 +65,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({"SameParameterValue", "deprecation"})
 @ExtendWith(SimulacronExtension.class)
+@ExtendWith(StreamInterceptingExtension.class)
 @ExtendWith(LogInterceptingExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SimulacronConfig(version = "5.0.8")
@@ -80,7 +86,13 @@ class SimpleEndToEndSimulacronIT {
           .put("kafka_internal_timestamp", "bigint")
           .build();
 
-  SimpleEndToEndSimulacronIT(BoundCluster simulacron, @LogCapture LogInterceptor logs) {
+  @SuppressWarnings("unused")
+  SimpleEndToEndSimulacronIT(
+      BoundCluster simulacron,
+      @LogCapture LogInterceptor logs,
+      @StreamCapture(STDOUT) StreamInterceptor stdOut,
+      @StreamCapture(STDERR) StreamInterceptor stdErr) {
+
     this.simulacron = simulacron;
     this.logs = logs;
 


### PR DESCRIPTION
* Also add/restore stream-capturing logic in simulacron tests to
  avoid polluting stdout/stderr.