### PR TITLE
KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -23,3 +23,4 @@
 - [bug] KAF-33: Connector loses records when DSE connection is lost
 - [bug] KAF-34: Package a simple README.md in the Kafka connector bundle
 - [bug] KAF-35: Connector causes spurious DEBUG logging in Confluent 3.2.1 connect infrastructure
+- [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible

--- a/src/it/java/com/datastax/kafkaconnector/simulacron/SimpleEndToEndSimulacronIT.java
+++ b/src/it/java/com/datastax/kafkaconnector/simulacron/SimpleEndToEndSimulacronIT.java
@@ -15,6 +15,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.serverError;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -35,12 +36,16 @@ import com.datastax.dsbulk.commons.tests.simulacron.annotations.SimulacronConfig
 import com.datastax.kafkaconnector.DseSinkConnector;
 import com.datastax.kafkaconnector.DseSinkTask;
 import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.datastax.oss.protocol.internal.request.Execute;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
 import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
 import com.datastax.oss.simulacron.common.request.Query;
+import com.datastax.oss.simulacron.common.request.Statement;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -281,6 +286,189 @@ class SimpleEndToEndSimulacronIT {
         fail("%s is not for table1 nor table2!", queryLog.toString());
       }
     }
+  }
+
+  @Test
+  void undefined_topic() {
+    SimulacronUtils.primeTables(simulacron, schema);
+
+    Query good1 = makeQuery(42, "the answer", 153000987000L);
+    simulacron.prime(when(good1).then(noRows()));
+
+    conn.start(connectorProperties);
+
+    SinkRecord goodRecord = makeRecord(42, "the answer", 153000987L, 1234);
+
+    SinkRecord badRecord = new SinkRecord("unknown", 0, null, 42L, null, 42, 1234L);
+    runTaskWithRecords(goodRecord, badRecord);
+    assertThat(logs.getAllMessagesAsString())
+        .contains("Error inserting row for Kafka record SinkRecord{kafkaOffset=1234")
+        .contains(
+            "Connector has no configuration for record topic 'unknown'. Please update the configuration and restart.");
+
+    // Verify that the insert for good1 was issued.
+    List<QueryLog> queryList =
+        simulacron
+            .node(0)
+            .getLogs()
+            .getQueryLogs()
+            .stream()
+            .filter(q -> q.getType().equals("EXECUTE"))
+            .collect(Collectors.toList());
+    byte[] secondParam = new byte[10];
+    ((Execute) queryList.get(0).getFrame().message)
+        .options
+        .positionalValues
+        .get(1)
+        .get(secondParam);
+    assertThat(new String(secondParam, StandardCharsets.UTF_8)).isEqualTo("the answer");
+  }
+
+  @Test
+  void batch_requests() {
+    // Insert 5 records: 2 from mytopic, 3 from yourtopic. Verify that they batch properly and
+    // with the correct CLs.
+
+    // Even though we will not be executing simple statements in this test, we must specify
+    // that we will so that Simulacron handles preparing our statement properly.
+    SimulacronUtils.primeTables(simulacron, schema);
+    Query good1 = makeQuery(42, "the answer", 153000987000L);
+    simulacron.prime(when(good1).then(noRows()));
+    Query good2 =
+        new Query(
+            "INSERT INTO ks1.table2(a,b) VALUES (:a,:b) USING TIMESTAMP :kafka_internal_timestamp",
+            Collections.emptyList(),
+            makeParams(42, "topic2 success1", 153000987000L),
+            PARAM_TYPES);
+    simulacron.prime(when(good2).then(noRows()));
+
+    conn.start(connectorProperties);
+
+    SinkRecord goodRecord1 = makeRecord(42, "the answer", 153000987L, 1234);
+    SinkRecord goodRecord2 = makeRecord(42, "the second answer", 153000987L, 1234);
+    SinkRecord goodRecord3 =
+        new SinkRecord(
+            "yourtopic",
+            0,
+            null,
+            42,
+            null,
+            "topic2 success1",
+            1235L,
+            153000987L,
+            TimestampType.CREATE_TIME);
+    SinkRecord goodRecord4 =
+        new SinkRecord(
+            "yourtopic",
+            0,
+            null,
+            42,
+            null,
+            "topic2 success2",
+            1235L,
+            153000987L,
+            TimestampType.CREATE_TIME);
+    SinkRecord goodRecord5 =
+        new SinkRecord(
+            "yourtopic",
+            0,
+            null,
+            42,
+            null,
+            "topic2 success3",
+            1235L,
+            153000987L,
+            TimestampType.CREATE_TIME);
+
+    // The order of records shouldn't matter here, but we try to mix things up to emulate
+    // a real workload.
+    runTaskWithRecords(goodRecord1, goodRecord3, goodRecord2, goodRecord4, goodRecord5);
+
+    // Verify that we issued two batch requests, one at LOCAL_ONE (for table1/mytopic) and
+    // one at QUORUM (for table2/yourtopic). There's seem pretty gnarly unwrapping of request
+    // info. We distinguish one batch from the other based on the number of statements in the
+    // batch.
+    List<QueryLog> queryList =
+        simulacron
+            .node(0)
+            .getLogs()
+            .getQueryLogs()
+            .stream()
+            .filter(q -> q.getType().equals("BATCH"))
+            .collect(Collectors.toList());
+    Map<ConsistencyLevel, Integer> queryInfo =
+        queryList
+            .stream()
+            .map(queryLog -> (Batch) queryLog.getFrame().message)
+            .collect(
+                Collectors.toMap(
+                    message -> ConsistencyLevel.fromCode(message.consistency),
+                    message -> message.values.size()));
+    assertThat(queryInfo)
+        .containsOnly(entry(ConsistencyLevel.LOCAL_ONE, 2), entry(ConsistencyLevel.QUORUM, 3));
+  }
+
+  @Test
+  void fail_batch_request() {
+    // Test single topic, multiple Kafka partitions, single C* partition, fail DSE batch request:
+    // single batch statement failure causes failureOffsets for all SinkRecord's in the batch.
+    SimulacronUtils.primeTables(simulacron, schema);
+    Query good1 = makeQuery(42, "the answer", 153000987000L);
+    simulacron.prime(when(good1).then(noRows()));
+
+    Statement s1 =
+        new Statement(
+            "INSERT INTO ks1.table1(a,b) VALUES (:a,:b) USING TIMESTAMP :kafka_internal_timestamp",
+            PARAM_TYPES,
+            makeParams(42, "the answer", 153000987000L));
+    Statement s2 =
+        new Statement(
+            "INSERT INTO ks1.table1(a,b) VALUES (:a,:b) USING TIMESTAMP :kafka_internal_timestamp",
+            PARAM_TYPES,
+            makeParams(42, "the second answer", 153000987000L));
+    com.datastax.oss.simulacron.common.request.Batch batchRequest =
+        new com.datastax.oss.simulacron.common.request.Batch(
+            Arrays.asList(s1, s2), new String[] {"LOCAL_ONE", "LOCAL_ONE"});
+
+    simulacron.prime(when(batchRequest).then(serverError("bad thing")));
+
+    SinkRecord record1 = makeRecord(0, 42, "the answer", 153000987000L, 1234);
+    SinkRecord record2 = makeRecord(1, 42, "the second answer", 153000987000L, 8888);
+
+    conn.start(connectorProperties);
+    runTaskWithRecords(record1, record2);
+
+    // Verify that one Batch request was issued, and no EXECUTE requests:
+    long batchRequestCount =
+        simulacron
+            .node(0)
+            .getLogs()
+            .getQueryLogs()
+            .stream()
+            .filter(q -> q.getType().equals("BATCH"))
+            .count();
+    long executeRequestCount =
+        simulacron
+            .node(0)
+            .getLogs()
+            .getQueryLogs()
+            .stream()
+            .filter(q -> q.getType().equals("EXECUTE"))
+            .count();
+    assertThat(batchRequestCount).isEqualTo(1L);
+    assertThat(executeRequestCount).isEqualTo(0L);
+
+    // Verify that we get error offsets for both records.
+    Map<TopicPartition, OffsetAndMetadata> currentOffsets = new HashMap<>();
+    task.preCommit(currentOffsets);
+    assertThat(currentOffsets)
+        .containsOnly(
+            Assertions.entry(new TopicPartition("mytopic", 0), new OffsetAndMetadata(1234L)),
+            Assertions.entry(new TopicPartition("mytopic", 1), new OffsetAndMetadata(8888L)));
+
+    assertThat(logs.getAllMessagesAsString())
+        .contains("Error inserting row for Kafka record SinkRecord{kafkaOffset=1234")
+        .contains("Error inserting row for Kafka record SinkRecord{kafkaOffset=8888");
   }
 
   private static SinkRecord makeRecord(int key, String value, long timestamp, long offset) {

--- a/src/main/java/com/datastax/kafkaconnector/DseSinkTask.java
+++ b/src/main/java/com/datastax/kafkaconnector/DseSinkTask.java
@@ -13,35 +13,50 @@ import static com.datastax.kafkaconnector.DseSinkTask.State.STOP;
 import static com.datastax.kafkaconnector.DseSinkTask.State.WAIT;
 import static com.datastax.kafkaconnector.util.SinkUtil.NAME_OPT;
 
-import com.datastax.dse.driver.api.core.DseSession;
 import com.datastax.kafkaconnector.codecs.KafkaCodecRegistry;
 import com.datastax.kafkaconnector.config.TopicConfig;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +69,9 @@ public class DseSinkTask extends SinkTask {
   private Map<TopicPartition, OffsetAndMetadata> failureOffsets;
   private AtomicReference<State> state;
   private CountDownLatch stopLatch;
+  private ExecutorService boundStatementProcessorService =
+      Executors.newFixedThreadPool(
+          1, new ThreadFactoryBuilder().setNameFormat("bound-statement-processor-%d").build());
 
   @Override
   public String version() {
@@ -93,129 +111,34 @@ public class DseSinkTask extends SinkTask {
     state.compareAndSet(State.WAIT, State.RUN);
 
     failureOffsets.clear();
-    DseSession session = instanceState.getSession();
 
     Instant start = Instant.now();
-    long totalMappingTimeMs = 0;
-    long waitTime = 0;
-    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    List<CompletableFuture<Void>> mappingFutures;
     Collection<CompletionStage<AsyncResultSet>> queryFutures = new ConcurrentLinkedQueue<>();
+    BlockingQueue<RecordAndStatement> boundStatementsQueue = new LinkedBlockingQueue<>();
+    BoundStatementProcessor boundStatementProcessor =
+        new BoundStatementProcessor(boundStatementsQueue, queryFutures);
     try {
-      Semaphore requestBarrier = instanceState.getRequestBarrier();
-      for (SinkRecord record : sinkRecords) {
-        String topicName = record.topic();
-        TopicPartition topicPartition = new TopicPartition(topicName, record.kafkaPartition());
-        CompletableFuture<BoundStatement> res =
-            CompletableFuture.supplyAsync(
-                () -> {
-                  Instant startMapping = Instant.now();
-                  //          if (state.get() == STOP) {
-                  //            // If the task is stopping abandon what we're doing.
-                  //            break;
-                  //          }
-                  //          if (failureOffsets.containsKey(topicPartition)) {
-                  //            // We've had a failure on this topic/partition already, so we don't
-                  // want to process
-                  //            // more records for this topic/partition.
-                  //            // NB: We could lock failureOffsets before access, as we do for
-                  // writes in query result
-                  //            // callbacks; but at it is, having this check is an optimization. If
-                  // our timing is just
-                  //            // a bit off and we don't see an entry that is actually there, we'll
-                  // process one
-                  //            // more record from the collection unnecessarily. Not really a big
-                  // deal. Better to not
-                  //            // lock and be more efficient in the common case (where there is no
-                  // error and thus
-                  //            // failureOffsets is empty). Besides, we use a ConcurrentHashMap, so
-                  // the entry will
-                  //            // either be there or not; no inconsistent state.
-                  //            log.trace(
-                  //                "Skipping record with offset {} for topic/partition {} because a
-                  // failure occurred when processing a previous record from this topic/partition",
-                  //                record.kafkaOffset(),
-                  //                topicPartition);
-                  //            continue;
-                  //          }
-                  KafkaCodecRegistry codecRegistry = instanceState.getCodecRegistry(topicName);
-                  PreparedStatement preparedStatement =
-                      instanceState.getPreparedInsertStatement(topicName);
-                  TopicConfig topicConfig = instanceState.getTopicConfig(topicName);
-                  Mapping mapping =
-                      mappingObjects.get(
-                          topicName, t -> new Mapping(topicConfig.getMapping(), codecRegistry));
-                  try {
-                    InnerDataAndMetadata key = makeMeta(record.key());
-                    InnerDataAndMetadata value = makeMeta(record.value());
-                    KeyValueRecord keyValueRecord =
-                        new KeyValueRecord(key.innerData, value.innerData, record.timestamp());
-                    RecordMapper mapper =
-                        new RecordMapper(
-                            preparedStatement,
-                            mapping,
-                            new KeyValueRecordMetadata(key.innerMetadata, value.innerMetadata),
-                            topicConfig.isNullToUnset(),
-                            true,
-                            false);
-                    BoundStatement boundStatement =
-                        mapper
-                            .map(keyValueRecord)
-                            .setConsistencyLevel(topicConfig.getConsistencyLevel());
-                    //            totalMappingTimeMs += Duration.between(startMapping,
-                    // Instant.now()).toNanos();
-                    return boundStatement;
-                  } catch (IOException e) {
-                    // This can only theoretically happen when processing json data. But bad json
-                    // won't result
-                    // in this exception. We're not pulling data from a file or any other kind of
-                    // IO.
-                    // Most likely this error can't occur in this application...but we try to
-                    // protect
-                    // ourselves anyway just in case.
-                    handleFailure(
-                        topicPartition, record, e, instanceState.getInsertStatement(topicName));
-                  }
-                  return null;
-                });
-        futures.add(
-            res.thenAccept(
-                boundStatement -> {
-                  try {
-                    Instant waitStart = Instant.now();
-                    requestBarrier.acquire();
-                    //            waitTime += Duration.between(waitStart, Instant.now()).toNanos();
-                    CompletionStage<AsyncResultSet> future = session.executeAsync(boundStatement);
-                    queryFutures.add(future);
-                    future.whenComplete(
-                        (result, ex) -> {
-                          requestBarrier.release();
-                          if (ex != null) {
-                            handleFailure(
-                                topicPartition,
-                                record,
-                                ex,
-                                instanceState.getInsertStatement(topicName));
-                          }
-                        });
-                    //          } catch (IOException e) {
-                    //            // This can only theoretically happen when processing json data.
-                    // But bad json won't result
-                    //            // in this exception. We're not pulling data from a file or any
-                    // other kind of IO.
-                    //            // Most likely this error can't occur in this application...but we
-                    // try to protect
-                    //            // ourselves anyway just in case.
-                    //            handleFailure(topicPartition, record, e,
-                    // instanceState.getInsertStatement(topicName));
-                  } catch (InterruptedException e) {
-                    e.printStackTrace();
-                  }
-                }));
-      }
+      Future<?> boundStatementProcessorTask =
+          boundStatementProcessorService.submit(boundStatementProcessor);
+      mappingFutures =
+          sinkRecords
+              .stream()
+              .map(
+                  record ->
+                      CompletableFuture.runAsync(
+                          () -> mapAndQueueRecord(boundStatementsQueue, record),
+                          instanceState.getMappingExecutor()))
+              .collect(Collectors.toList());
 
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[1])).get();
-      //      CompletableFuture.allOf(queryFutures.toArray(new CompletableFuture[1])).get();
-      //      // Wait for outstanding requests to complete.
+      CompletableFuture.allOf(mappingFutures.toArray(new CompletableFuture[0])).join();
+      boundStatementProcessor.stop();
+      try {
+        boundStatementProcessorTask.get();
+      } catch (ExecutionException e) {
+        // No-op.
+      }
+      log.debug("Query futures: {}", queryFutures.size());
       for (CompletionStage<AsyncResultSet> f : queryFutures) {
         try {
           f.toCompletableFuture().get();
@@ -227,16 +150,13 @@ public class DseSinkTask extends SinkTask {
 
       Instant end = Instant.now();
       long ms = Duration.between(start, end).toMillis();
-      log.debug(
-          "Completed {} inserts in {} ms", // \nmappingTime: {} ns\nwaitTime: {} ns\nfinalWait: {}
-          // ns",
-          queryFutures.size() - failureOffsets.size(),
-          ms // ,
-          //          totalMappingTimeMs,
-          //          waitTime,
-          //          Duration.between(finalWaitStart, end).toNanos()
-          );
+      log.info(
+          "Completed {}/{} inserts in {} ms",
+          boundStatementProcessor.getSuccessfulRecordCount(),
+          sinkRecords.size(),
+          ms);
     } catch (InterruptedException e) {
+      boundStatementProcessor.stop();
       queryFutures.forEach(
           f -> {
             f.toCompletableFuture().cancel(true);
@@ -248,8 +168,6 @@ public class DseSinkTask extends SinkTask {
           });
 
       throw new RetriableException("Interrupted while issuing queries");
-    } catch (ExecutionException e) {
-      e.printStackTrace();
     } finally {
       state.compareAndSet(State.RUN, State.WAIT);
       if (state.get() == STOP) {
@@ -257,6 +175,45 @@ public class DseSinkTask extends SinkTask {
         stopLatch.countDown();
       }
     }
+  }
+
+  private void mapAndQueueRecord(
+      BlockingQueue<RecordAndStatement> boundStatementsQueue, SinkRecord record) {
+    try {
+      boundStatementsQueue.offer(new RecordAndStatement(record, mapRecord(record)));
+    } catch (KafkaException e) {
+      // The Kafka exception could occur if the record references an unknown topic.
+      handleFailure(record, e, null);
+    } catch (IOException e) {
+      // The IOException can only theoretically happen when processing json data. But bad json
+      // won't result in this exception. We're not pulling data from a file or any other kind of IO.
+      // Most likely this error can't occur in this application...but we try to protect ourselves
+      // anyway just in case.
+      String topicName = record.topic();
+      handleFailure(record, e, instanceState.getInsertStatement(topicName));
+    }
+  }
+
+  private BoundStatement mapRecord(SinkRecord record) throws IOException {
+    String topicName = record.topic();
+    KafkaCodecRegistry codecRegistry = instanceState.getCodecRegistry(topicName);
+    PreparedStatement preparedStatement = instanceState.getPreparedInsertStatement(topicName);
+    TopicConfig topicConfig = instanceState.getTopicConfig(topicName);
+    Mapping mapping =
+        mappingObjects.get(topicName, t -> new Mapping(topicConfig.getMapping(), codecRegistry));
+    InnerDataAndMetadata key = makeMeta(record.key());
+    InnerDataAndMetadata value = makeMeta(record.value());
+    KeyValueRecord keyValueRecord =
+        new KeyValueRecord(key.innerData, value.innerData, record.timestamp());
+    RecordMapper mapper =
+        new RecordMapper(
+            preparedStatement,
+            mapping,
+            new KeyValueRecordMetadata(key.innerMetadata, value.innerMetadata),
+            topicConfig.isNullToUnset(),
+            true,
+            false);
+    return mapper.map(keyValueRecord).setConsistencyLevel(topicConfig.getConsistencyLevel());
   }
 
   @Override
@@ -291,10 +248,9 @@ public class DseSinkTask extends SinkTask {
     }
   }
 
-  private synchronized void handleFailure(
-      TopicPartition topicPartition, SinkRecord record, Throwable e, String cql) {
+  private synchronized void handleFailure(SinkRecord record, Throwable e, String cql) {
     // Store the topic-partition and offset that had an error. However, we want
-    // to keep track of the *lowest* offset in a topic-partiton that failed. Because
+    // to keep track of the *lowest* offset in a topic-partition that failed. Because
     // requests are sent in parallel and response ordering is non-deterministic,
     // it's possible for a failure in an insert with a higher offset be detected
     // before that of a lower offset. Thus, we only record a failure if
@@ -304,6 +260,8 @@ public class DseSinkTask extends SinkTask {
     // This can happen in multiple invocations of this callback concurrently, so
     // we perform these checks/updates in a synchronized block. Presumably failures
     // don't occur that often, so we don't have to be very fancy here.
+
+    TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
     long currentOffset = Long.MAX_VALUE;
     if (failureOffsets.containsKey(topicPartition)) {
       currentOffset = failureOffsets.get(topicPartition).offset();
@@ -313,11 +271,10 @@ public class DseSinkTask extends SinkTask {
       context.offset(topicPartition, record.kafkaOffset());
     }
 
+    String statementError = cql != null ? String.format("\n   statement: %s", cql) : "";
+
     log.warn(
-        "Error inserting row for Kafka record {}: {}\n   statement: {}",
-        record,
-        e.getMessage(),
-        cql);
+        "Error inserting row for Kafka record {}: {}{}", record, e.getMessage(), statementError);
   }
 
   private static InnerDataAndMetadata makeMeta(Object keyOrValue) throws IOException {
@@ -366,6 +323,148 @@ public class DseSinkTask extends SinkTask {
     InnerDataAndMetadata(KeyOrValue innerData, RecordMetadata innerMetadata) {
       this.innerMetadata = innerMetadata;
       this.innerData = innerData;
+    }
+  }
+
+  /**
+   * Runnable class that pulls [sink-record, bound-statement] pairs from a queue and groups them
+   * based on topic and routing-key, and then issues batch statements when groups are large enough
+   * (currently 32). Execute BoundStatement's when there is only one in a group and we know no more
+   * BoundStatements will be added to the queue.
+   */
+  private class BoundStatementProcessor implements Runnable {
+    private static final int MAX_BATCH_SIZE = 32;
+    private final RecordAndStatement END_STATEMENT = new RecordAndStatement(null, null);
+    private final BlockingQueue<RecordAndStatement> boundStatementsQueue;
+    private final Collection<CompletionStage<AsyncResultSet>> queryFutures;
+    private final AtomicInteger successfulRecordCount = new AtomicInteger();
+
+    BoundStatementProcessor(
+        BlockingQueue<RecordAndStatement> boundStatementsQueue,
+        Collection<CompletionStage<AsyncResultSet>> queryFutures) {
+      this.boundStatementsQueue = boundStatementsQueue;
+      this.queryFutures = queryFutures;
+    }
+
+    private void queueStatements(List<RecordAndStatement> statements) {
+      Statement statement;
+      if (statements.size() == 1) {
+        statement = statements.get(0).getStatement();
+      } else {
+        BatchStatementBuilder bsb = BatchStatement.builder(DefaultBatchType.UNLOGGED);
+        statements.stream().map(RecordAndStatement::getStatement).forEach(bsb::addStatement);
+        // Construct the batch statement; set its consistency level to that of its first
+        // bound statement. All bound statements in a bucket have the same CL, so this is fine.
+        statement =
+            bsb.build().setConsistencyLevel(statements.get(0).getStatement().getConsistencyLevel());
+      }
+      @NotNull Semaphore requestBarrier = instanceState.getRequestBarrier();
+      requestBarrier.acquireUninterruptibly();
+      CompletionStage<AsyncResultSet> future = instanceState.getSession().executeAsync(statement);
+      queryFutures.add(future);
+      future.whenComplete(
+          (result, ex) -> {
+            requestBarrier.release();
+            if (ex != null) {
+              statements.forEach(
+                  recordAndStatement -> {
+                    SinkRecord record = recordAndStatement.getRecord();
+                    handleFailure(record, ex, instanceState.getInsertStatement(record.topic()));
+                  });
+            } else {
+              successfulRecordCount.addAndGet(statements.size());
+            }
+          });
+    }
+
+    int getSuccessfulRecordCount() {
+      return successfulRecordCount.get();
+    }
+
+    @Override
+    public void run() {
+      // Map of <topic, map<partition-key, list<recordAndStatement>>
+      Map<String, Map<ByteBuffer, List<RecordAndStatement>>> statementGroups = new HashMap<>();
+      List<RecordAndStatement> pendingStatements = new ArrayList<>();
+      boolean interrupted = false;
+      try {
+        //noinspection InfiniteLoopStatement
+        while (true) {
+          if (state.get() == STOP) {
+            // If the task is stopping abandon what we're doing.
+            return;
+          }
+          pendingStatements.clear();
+          boundStatementsQueue.drainTo(pendingStatements);
+          if (pendingStatements.isEmpty()) {
+            try {
+              pendingStatements.add(boundStatementsQueue.take());
+            } catch (InterruptedException e) {
+              interrupted = true;
+              continue;
+            }
+          }
+
+          for (RecordAndStatement recordAndStatement : pendingStatements) {
+            if (recordAndStatement.equals(END_STATEMENT)) {
+              // There are no more bound-statements being produced.
+              // Create and execute remaining statement groups,
+              // creating BatchStatement's when a group has more than
+              // one BoundStatement.
+              statementGroups
+                  .values()
+                  .stream()
+                  .map(Map::values)
+                  .flatMap(Collection::stream)
+                  .forEach(this::queueStatements);
+              return;
+            }
+
+            // Get the routing-key and add this statement to the appropriate
+            // statement group.
+
+            ByteBuffer routingKey = recordAndStatement.getStatement().getRoutingKey();
+            Map<ByteBuffer, List<RecordAndStatement>> topicGroup =
+                statementGroups.computeIfAbsent(
+                    recordAndStatement.getRecord().topic(), t -> new HashMap<>());
+            List<RecordAndStatement> recordsAndStatements =
+                topicGroup.computeIfAbsent(routingKey, t -> new ArrayList<>());
+            recordsAndStatements.add(recordAndStatement);
+            if (recordsAndStatements.size() == MAX_BATCH_SIZE) {
+              // We're ready to send out a batch request!
+              queueStatements(recordsAndStatements);
+              recordsAndStatements.clear();
+            }
+          }
+        }
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    void stop() {
+      boundStatementsQueue.add(END_STATEMENT);
+    }
+  }
+
+  /** Simple container class to hold a SinkRecord and its associated BoundStatement. */
+  private static class RecordAndStatement {
+    private final SinkRecord record;
+    private final BoundStatement statement;
+
+    RecordAndStatement(SinkRecord record, BoundStatement statement) {
+      this.record = record;
+      this.statement = statement;
+    }
+
+    SinkRecord getRecord() {
+      return record;
+    }
+
+    BoundStatement getStatement() {
+      return statement;
     }
   }
 }


### PR DESCRIPTION
* Use a fixed thread-pool for mapping tasks with thread names 'mapping-%d'
* Mapping tasks map SinkRecord's to BoundStatement's and add them to
   a queue.
* A dedicated "bound-statement-processor" thread pulls the statements
   from the queue, groups them by routing-key, and issues a batch
   request when a group has 32 bound statements.