### PR TITLE
KAF-36: Kafka Sink fails when optional schema types are used in Avro schema

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.0.0-alpha2
+- [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible
+- [bug] KAF-36: Kafka Sink fails when optional schema types are used in Avro schema
+
 ### 1.0.0-alpha1
 - [new feature] KAF-1: Support JSON Records
 - [improvement] KAF-2: Replace duped dsbulk commons code with a ref to the new dsbulk-commons-1.2.0-ng
@@ -23,4 +27,3 @@
 - [bug] KAF-33: Connector loses records when DSE connection is lost
 - [bug] KAF-34: Package a simple README.md in the Kafka connector bundle
 - [bug] KAF-35: Connector causes spurious DEBUG logging in Confluent 3.2.1 connect infrastructure
-- [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible

--- a/src/main/java/com/datastax/kafkaconnector/StructDataMetadata.java
+++ b/src/main/java/com/datastax/kafkaconnector/StructDataMetadata.java
@@ -17,17 +17,17 @@ import org.jetbrains.annotations.NotNull;
 
 /** Metadata associated with a {@link StructData}. */
 public class StructDataMetadata implements RecordMetadata {
-  private static final ImmutableMap<Schema, GenericType<?>> TYPE_MAP =
-      ImmutableMap.<Schema, GenericType<?>>builder()
-          .put(Schema.BOOLEAN_SCHEMA, GenericType.BOOLEAN)
-          .put(Schema.FLOAT64_SCHEMA, GenericType.DOUBLE)
-          .put(Schema.INT64_SCHEMA, GenericType.LONG)
-          .put(Schema.FLOAT32_SCHEMA, GenericType.FLOAT)
-          .put(Schema.INT8_SCHEMA, GenericType.BYTE)
-          .put(Schema.INT16_SCHEMA, GenericType.SHORT)
-          .put(Schema.INT32_SCHEMA, GenericType.INTEGER)
-          .put(Schema.STRING_SCHEMA, GenericType.STRING)
-          .put(Schema.BYTES_SCHEMA, GenericType.BYTE_BUFFER)
+  private static final ImmutableMap<Schema.Type, GenericType<?>> TYPE_MAP =
+      ImmutableMap.<Schema.Type, GenericType<?>>builder()
+          .put(Schema.Type.BOOLEAN, GenericType.BOOLEAN)
+          .put(Schema.Type.FLOAT64, GenericType.DOUBLE)
+          .put(Schema.Type.INT64, GenericType.LONG)
+          .put(Schema.Type.FLOAT32, GenericType.FLOAT)
+          .put(Schema.Type.INT8, GenericType.BYTE)
+          .put(Schema.Type.INT16, GenericType.SHORT)
+          .put(Schema.Type.INT32, GenericType.INTEGER)
+          .put(Schema.Type.STRING, GenericType.STRING)
+          .put(Schema.Type.BYTES, GenericType.BYTE_BUFFER)
           .build();
   private final Schema schema;
 
@@ -46,12 +46,12 @@ public class StructDataMetadata implements RecordMetadata {
 
   @NotNull
   private GenericType<?> getGenericType(@NotNull Schema fieldType) {
-    GenericType<?> result = TYPE_MAP.get(fieldType);
+    GenericType<?> result = TYPE_MAP.get(fieldType.type());
     if (result != null) {
       return result;
     }
     // This is a complex type.
-    // TODO: PERF: Cache these results and check the cache before creating
+    // TODO: PERF: Consider caching these results and check the cache before creating
     // new entries.
 
     switch (fieldType.type()) {


### PR DESCRIPTION
* Update type mapping in StructDataMetadata to use the "type" of the
  schema rather than the schema itself.
* Add support for default values in schemas.