### PR TITLE
KAF-37: Using a boolean field in a UDT causes CodecNotFoundException

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 1.0.0-alpha2
 - [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible
 - [bug] KAF-36: Kafka Sink fails when optional schema types are used in Avro schema
+- [bug] KAF-37: Using a boolean field in a UDT causes CodecNotFoundException
 
 ### 1.0.0-alpha1
 - [new feature] KAF-1: Support JSON Records


### PR DESCRIPTION
* Actual fix is in dsbulk commons code, adding
  BooleanToStringCodec and BooleanToBooleanCodec converting codecs.