### PR TITLE
KAF-40: When testing against DSE 5.0, tests fail because DateRange type doesn't exist

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 - [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible
 - [bug] KAF-36: Kafka Sink fails when optional schema types are used in Avro schema
 - [bug] KAF-37: Using a boolean field in a UDT causes CodecNotFoundException
+- [bug] KAF-40: When testing against DSE 5.0, tests fail because DateRange type doesn't exist
 
 ### 1.0.0-alpha1
 - [new feature] KAF-1: Support JSON Records

--- a/src/main/java/com/datastax/kafkaconnector/DseSinkTask.java
+++ b/src/main/java/com/datastax/kafkaconnector/DseSinkTask.java
@@ -150,7 +150,7 @@ public class DseSinkTask extends SinkTask {
 
       Instant end = Instant.now();
       long ms = Duration.between(start, end).toMillis();
-      log.info(
+      log.debug(
           "Completed {}/{} inserts in {} ms",
           boundStatementProcessor.getSuccessfulRecordCount(),
           sinkRecords.size(),


### PR DESCRIPTION
* Add logic in SimpleEndToEndCCMIT test to detect DSE version and
  skip DateRange type testing for 5.0.x.