### PR TITLE
KAF-41: Byte array values cause CodecNotFoundException

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [new feature] KAF-19: Add plaintext authentication
 - [new feature] KAF-20: Add Kerberos authentication
 - [new feature] KAF-5: Support Counter type
+- [bug] KAF-41: Byte array values cause CodecNotFoundException
 
 ### 1.0.0-alpha2
 - [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible

--- a/src/it/java/com/datastax/kafkaconnector/ccm/SimpleEndToEndCCMIT.java
+++ b/src/it/java/com/datastax/kafkaconnector/ccm/SimpleEndToEndCCMIT.java
@@ -499,6 +499,22 @@ class SimpleEndToEndCCMIT extends EndToEndCCMITBase {
   }
 
   @Test
+  void raw_byte_array_value() {
+    conn.start(makeConnectorProperties("bigintcol=key, blobcol=value"));
+
+    byte[] bytes = new byte[] {1, 2, 3};
+    SinkRecord record = new SinkRecord("mytopic", 0, null, 98761234L, null, bytes, 1234L);
+    runTaskWithRecords(record);
+
+    // Verify that the record was inserted properly in DSE.
+    List<Row> results = session.execute("SELECT bigintcol, blobcol FROM types").all();
+    assertThat(results.size()).isEqualTo(1);
+    Row row = results.get(0);
+    assertThat(row.getLong("bigintcol")).isEqualTo(98761234L);
+    assertThat(row.getByteBuffer("blobcol").array()).isEqualTo(bytes);
+  }
+
+  @Test
   void raw_list_value_from_json() {
     conn.start(makeConnectorProperties("bigintcol=key, listcol=value"));
 

--- a/src/main/java/com/datastax/kafkaconnector/RawData.java
+++ b/src/main/java/com/datastax/kafkaconnector/RawData.java
@@ -10,6 +10,7 @@ package com.datastax.kafkaconnector;
 
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -28,9 +29,12 @@ public class RawData implements KeyOrValue, RecordMetadata {
   private final Object value;
 
   RawData(Object keyOrValue) {
-    value = keyOrValue;
-    if (keyOrValue != null) {
-      type = GenericType.of(keyOrValue.getClass());
+    // The driver requires a ByteBuffer rather than byte[] when inserting a blob.
+    value = keyOrValue instanceof byte[] ? ByteBuffer.wrap((byte[]) keyOrValue) : keyOrValue;
+
+    if (value != null) {
+      type =
+          value instanceof ByteBuffer ? GenericType.BYTE_BUFFER : GenericType.of(value.getClass());
     } else {
       type = GenericType.STRING;
     }


### PR DESCRIPTION
* Update RawData to convert byte[] to ByteBuffer, which the
  codec registry can process.