### PR TITLE
KAF-15: Gather metrics and report via JMX

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [new feature] KAF-5: Support Counter type
 - [bug] KAF-41: Byte array values cause CodecNotFoundException
 - [improvement] KAF-10: Disallow connecting to C* nodes
+- [improvement] KAF-15: Gather metrics and report via JMX
 
 ### 1.0.0-alpha2
 - [improvement] KAF-38: Improve performance by parallelizing record mapping and using partition-key-based batches when possible

--- a/conf/dse-sink-distributed.json.sample
+++ b/conf/dse-sink-distributed.json.sample
@@ -8,6 +8,7 @@
         "loadBalancing.localDc": "",
         "port": 9042,
         "maxConcurrentRequests": 500,
+        "jmx": true,
         "auth.provider": "None",
         "auth.username": "",
         "auth.password": "",

--- a/conf/dse-sink-standalone.properties.sample
+++ b/conf/dse-sink-standalone.properties.sample
@@ -19,6 +19,9 @@ topics=my_topic
 # Maximum number of requests to send to DSE at a single time. Defaults to 500.
 #maxConcurrentRequests=500
 
+# Whether or not to enable stats reporting through JMX. Defaults to true.
+#jmx=true
+
 ### Authentication Setings ###
 
 # Authentication provider to use, if any. Valid choices: None, DSE, GSSAPI.

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <awaitility.version>3.1.0</awaitility.version>
     <netty.version>4.1.27.Final</netty.version>
     <netty.tcnative.version>2.0.15.Final</netty.tcnative.version>
+    <metrics.version>4.0.2</metrics.version>
   </properties>
 
   <dependencies>
@@ -218,6 +219,18 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${netty.tcnative.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+      <version>${metrics.version}</version>
     </dependency>
 
   </dependencies>
@@ -473,8 +486,6 @@ https://www.datastax.com/terms/datastax-dse-bulk-utility-license-terms.
         <configuration>
           <systemPropertyVariables>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
-            <!-- We need nodes to start up as 127.0.0.x because the hostname validation tests use a server-localhost keystore with 127.0.0.1. -->
-            <com.datastax.dsbulk.commons.tests.utils.DEFAULT_IP_PREFIX>127.0.0.</com.datastax.dsbulk.commons.tests.utils.DEFAULT_IP_PREFIX>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/src/main/java/com/datastax/kafkaconnector/config/DseSinkConfig.java
+++ b/src/main/java/com/datastax/kafkaconnector/config/DseSinkConfig.java
@@ -30,6 +30,7 @@ public class DseSinkConfig {
   static final String PORT_OPT = "port";
   static final String DC_OPT = "loadBalancing.localDc";
   static final String CONCURRENT_REQUESTS_OPT = "maxConcurrentRequests";
+  static final String JMX_OPT = "jmx";
   public static final ConfigDef GLOBAL_CONFIG_DEF =
       new ConfigDef()
           .define(
@@ -57,7 +58,13 @@ public class DseSinkConfig {
               500,
               ConfigDef.Range.atLeast(1),
               ConfigDef.Importance.HIGH,
-              "The maximum number of requests to send to DSE at once");
+              "The maximum number of requests to send to DSE at once")
+          .define(
+              JMX_OPT,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              ConfigDef.Importance.HIGH,
+              "Whether to enable JMX reporting");
 
   private static final Pattern TOPIC_PAT = Pattern.compile("topic\\.([^.]+)");
   private final String instanceName;
@@ -139,6 +146,10 @@ public class DseSinkConfig {
     return globalConfig.getInt(CONCURRENT_REQUESTS_OPT);
   }
 
+  public boolean getJmx() {
+    return globalConfig.getBoolean(JMX_OPT);
+  }
+
   public List<String> getContactPoints() {
     return globalConfig.getList(CONTACT_POINTS_OPT);
   }
@@ -167,6 +178,7 @@ public class DseSinkConfig {
             + "        port: %d%n"
             + "        localDc: %s%n"
             + "        maxConcurrentRequests: %d%n"
+            + "        jmx: %b%n"
             + "SSL configuration:%n%s%n"
             + "Authentication configuration:%n%s%n"
             + "Topic configurations:%n%s",
@@ -174,6 +186,7 @@ public class DseSinkConfig {
         getPort(),
         getLocalDc(),
         getMaxConcurrentRequests(),
+        getJmx(),
         Splitter.on("\n")
             .splitToList(sslConfig.toString())
             .stream()

--- a/src/main/java/com/datastax/kafkaconnector/util/TopicState.java
+++ b/src/main/java/com/datastax/kafkaconnector/util/TopicState.java
@@ -8,6 +8,8 @@
  */
 package com.datastax.kafkaconnector.util;
 
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.kafkaconnector.codecs.KafkaCodecRegistry;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 
@@ -16,15 +18,29 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
  * statement, etc.)
  */
 class TopicState {
+  private final String name;
   private final String cqlStatement;
   private final PreparedStatement preparedStatement;
   private final KafkaCodecRegistry codecRegistry;
+  private Histogram batchSizeHistogram;
 
   TopicState(
-      String cqlStatement, PreparedStatement preparedStatement, KafkaCodecRegistry codecRegistry) {
+      String name,
+      String cqlStatement,
+      PreparedStatement preparedStatement,
+      KafkaCodecRegistry codecRegistry) {
+    this.name = name;
     this.cqlStatement = cqlStatement;
     this.preparedStatement = preparedStatement;
     this.codecRegistry = codecRegistry;
+  }
+
+  void initializeMetrics(MetricRegistry metricRegistry) {
+    batchSizeHistogram = metricRegistry.histogram(String.format("%s/batchSize", name));
+  }
+
+  Histogram getBatchSizeHistogram() {
+    return batchSizeHistogram;
   }
 
   String getCqlStatement() {


### PR DESCRIPTION
* Add the following metrics to the Kafka connector:

recordCount - running total of the number of records processed
  by the connector instance, including avg number in the last
  1, 5, 15 minutes.
failedRecordCount - running total of the number of failed records
  encountered by the connector instance
  batchSize - histogram of request batch sizes for each topic.

* Add the following driver metrics:
cql-requests - histogram of latency of cql request processing
cql-client-timeouts - running total of the number of requests that
  timed out when communicating with a node.