### PR TITLE
STREAM-822: Add support for JDK 21

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         java:
           - '11'
+          - '17'
           - '21'
         cassandra:
           - cassandra_version: 3.0.27
@@ -44,12 +45,13 @@ jobs:
           - cassandra_version: dse-5.1
             ccm_version: 5.1.31
             is_dse: true
-          - cassandra_version: dse-6.0
-            ccm_version: 6.0.18
-            is_dse: true
-          - cassandra_version: dse-6.7
-            ccm_version: 6.7.17
-            is_dse: true
+            # DSE 6.0 and 6.7 are commented out because they are EOL and no longer supported by DataStax/IBM
+          #- cassandra_version: dse-6.0
+          #  ccm_version: 6.0.18
+          #  is_dse: true
+          #- cassandra_version: dse-6.7
+          #  ccm_version: 6.7.17
+          #  is_dse: true
           - cassandra_version: dse-6.8
             ccm_version: 6.8.24
             is_dse: true
@@ -104,7 +106,6 @@ jobs:
           #!/bin/bash
           set -e
           echo "Cloning the repo"
-          echo $CLONE_RIPTANO_CCM_SECRET
           git clone https://x-access-token:${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -28,6 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java:
+          - '11'
+          - '21'
         cassandra:
           - cassandra_version: 3.0.27
             ccm_version: 3.0.27
@@ -62,10 +65,10 @@ jobs:
         run: |
           export JDK8_PATH=$JAVA_HOME
           echo "JDK8_PATH=$JDK8_PATH" >> $GITHUB_ENV
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Pre set up Python
         run: |
@@ -92,6 +95,7 @@ jobs:
           #!/bin/bash
           set -e
           echo "Cloning the repo"
+          echo $CLONE_RIPTANO_CCM_SECRET
           git clone https://${CLONE_RIPTANO_CCM_SECRET}:x-oauth-basic@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -96,7 +96,7 @@ jobs:
           set -e
           echo "Cloning the repo"
           echo $CLONE_RIPTANO_CCM_SECRET
-          git clone https://${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
+          git clone https://${CLONE_RIPTANO_CCM_SECRET}:x-oauth-basic@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"
           pip install -r requirements.txt

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -90,13 +90,13 @@ jobs:
       - name: Setup CCM private
         if: ${{ matrix.cassandra.is_dse }}
         env:
-          CLONE_RIPTANO_CCM_SECRET: ${{secrets.CLONE_RIPTANO_CCM_SECRET}}
+          CLONE_RIPTANO_CCM_SECRET: ${{secrets.CLONE_RIPTANO_CCM_PRIVATE_SECRET}}
         run: |
           #!/bin/bash
           set -e
           echo "Cloning the repo"
           echo $CLONE_RIPTANO_CCM_SECRET
-          git clone https://x-access-token:${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
+          git clone https://${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"
           pip install -r requirements.txt

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -96,7 +96,7 @@ jobs:
           set -e
           echo "Cloning the repo"
           echo $CLONE_RIPTANO_CCM_SECRET
-          git clone https://${CLONE_RIPTANO_CCM_SECRET}:x-oauth-basic@github.com/riptano/ccm-private.git
+          git clone https://${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"
           pip install -r requirements.txt
@@ -115,7 +115,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build with JDK 11
+      - name: Build with JDK ${{ matrix.java }}
         run: mvn -B clean install -DskipTests
 
       - name: Run integration tests

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -96,7 +96,7 @@ jobs:
           set -e
           echo "Cloning the repo"
           echo $CLONE_RIPTANO_CCM_SECRET
-          git clone https://${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
+          git clone https://x-access-token:${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"
           pip install -r requirements.txt

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -96,7 +96,7 @@ jobs:
           set -e
           echo "Cloning the repo"
           echo $CLONE_RIPTANO_CCM_SECRET
-          git clone https://${CLONE_RIPTANO_CCM_SECRET}:x-oauth-basic@github.com/riptano/ccm-private.git
+          git clone https://x-access-token:${CLONE_RIPTANO_CCM_SECRET}@github.com/riptano/ccm-private.git
           cd ccm-private
           echo "pip install requirements"
           pip install -r requirements.txt

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -94,6 +94,8 @@ jobs:
         with:
           app-id: ${{ vars.RIPTANO_CCM_PRIVATE_APP_ID }}
           private-key: ${{ secrets.RIPTANO_CCM_APP_PRIVATE_KEY }}
+          owner: riptano
+          repositories: ccm-private
       - name: Setup CCM private
         if: ${{ matrix.cassandra.is_dse }}
         env:

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -87,10 +87,17 @@ jobs:
           cache: 'pip'
           allow-build: info
           cache-build: true
+      - name: Generate installation token for CCM private
+        if: ${{ matrix.cassandra.is_dse }}
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RIPTANO_CCM_PRIVATE_APP_ID }}
+          private-key: ${{ secrets.RIPTANO_CCM_APP_PRIVATE_KEY }}
       - name: Setup CCM private
         if: ${{ matrix.cassandra.is_dse }}
         env:
-          CLONE_RIPTANO_CCM_SECRET: ${{secrets.CLONE_RIPTANO_CCM_PRIVATE_SECRET}}
+          CLONE_RIPTANO_CCM_SECRET: ${{ steps.generate-token.outputs.token }}
         run: |
           #!/bin/bash
           set -e

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -116,6 +116,24 @@ jobs:
         run: |
           #!/bin/bash
           pip install ccm
+      - name: Configure CCM for DSE
+        if: ${{ matrix.cassandra.is_dse }}
+        env:
+          DSE_USERNAME: ${{ secrets.DSE_USERNAME }}
+          DSE_PASSWORD: ${{ secrets.DSE_PASSWORD }}
+        run: |
+          mkdir -p ~/.ccm
+            
+          cat <<EOF > ~/.ccm/config
+          [repositories]
+          dse = https://na.artifactory.swg-devops.com/artifactory/datastax-team-dse-packages-release-generic-local/dse-%s-bin.tar.gz
+          EOF
+            
+          cat <<EOF > ~/.ccm/.dse.ini
+          [dse_credentials]
+          dse_username = $DSE_USERNAME
+          dse_password = $DSE_PASSWORD
+          EOF
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         java:
           - '11'
+          - '21'
 
     steps:
       - uses: actions/checkout@v2

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -88,7 +88,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>META-INF/io.netty.versions.properties</resource>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -654,11 +654,47 @@ limitations under the License.]]></inlineHeader>
     </plugins>
   </build>
   <profiles>
-    <!-- NEW: Separate profile specifically for Java 21+ -->
+    <!-- NEW: Separate profile specifically for Java 17+ -->
     <profile>
       <id>jdk21</id>
       <activation>
         <jdk>[21..)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.15.0</version>
+              <configuration>
+                <source>${java.version}</source>
+                <target>${java.version}</target>
+                <release>${java.release.version}</release>
+                <showDeprecation>true</showDeprecation>
+                <showWarnings>true</showWarnings>
+                <failOnWarning>false</failOnWarning>
+                <fork>false</fork>
+                <compilerArgs>
+                  <arg>-XDcompilePolicy=simple</arg>
+                  <arg>-Xplugin:ErrorProne</arg>
+                </compilerArgs>
+                <annotationProcessorPaths>
+                  <path>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>2.49.0</version>
+                  </path>
+                </annotationProcessorPaths>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk17</id>
+      <activation>
+        <jdk>[17,21)</jdk>
       </activation>
       <build>
         <pluginManagement>
@@ -694,14 +730,14 @@ limitations under the License.]]></inlineHeader>
     <profile>
       <id>jdk11</id>
       <activation>
-        <jdk>[9,21)</jdk>
+        <jdk>[9,17)</jdk>
       </activation>
       <build>
         <pluginManagement>
           <plugins>
             <plugin>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.11.0</version>
+              <version>3.8.1</version>
               <configuration>
                 <source>${java.version}</source>
                 <target>${java.version}</target>
@@ -719,7 +755,7 @@ limitations under the License.]]></inlineHeader>
                   <path>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_core</artifactId>
-                    <version>2.28.0</version>
+                    <version>2.4.0</version>
                   </path>
                 </annotationProcessorPaths>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -654,11 +654,10 @@ limitations under the License.]]></inlineHeader>
     </plugins>
   </build>
   <profiles>
-    <!-- NEW: Separate profile specifically for Java 17+ -->
     <profile>
       <id>jdk21</id>
       <activation>
-        <jdk>[21..)</jdk>
+        <jdk>[21,)</jdk>
       </activation>
       <build>
         <pluginManagement>
@@ -671,12 +670,23 @@ limitations under the License.]]></inlineHeader>
                 <target>${java.version}</target>
                 <release>${java.release.version}</release>
                 <showDeprecation>true</showDeprecation>
-                <showWarnings>true</showWarnings>
                 <failOnWarning>false</failOnWarning>
-                <fork>false</fork>
+                <fork>true</fork>
                 <compilerArgs>
                   <arg>-XDcompilePolicy=simple</arg>
                   <arg>-Xplugin:ErrorProne</arg>
+                  <arg>-XDshould-stop.ifError=FLOW</arg>
+                  <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                 </compilerArgs>
                 <annotationProcessorPaths>
                   <path>
@@ -694,7 +704,7 @@ limitations under the License.]]></inlineHeader>
     <profile>
       <id>jdk17</id>
       <activation>
-        <jdk>[17,21)</jdk>
+        <jdk>[16,21)</jdk>
       </activation>
       <build>
         <pluginManagement>
@@ -707,18 +717,29 @@ limitations under the License.]]></inlineHeader>
                 <target>${java.version}</target>
                 <release>${java.release.version}</release>
                 <showDeprecation>true</showDeprecation>
-                <showWarnings>true</showWarnings>
                 <failOnWarning>false</failOnWarning>
-                <fork>false</fork>
+                <fork>true</fork>
                 <compilerArgs>
                   <arg>-XDcompilePolicy=simple</arg>
                   <arg>-Xplugin:ErrorProne</arg>
+                  <arg>-XDshould-stop.ifError=FLOW</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                 </compilerArgs>
                 <annotationProcessorPaths>
                   <path>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_core</artifactId>
-                    <version>2.28.0</version>
+                    <!-- From further version the minimum supported JDK version to run Error Prone is 21 -->
+                    <version>2.42.0</version>
                   </path>
                 </annotationProcessorPaths>
               </configuration>
@@ -730,7 +751,7 @@ limitations under the License.]]></inlineHeader>
     <profile>
       <id>jdk11</id>
       <activation>
-        <jdk>[9,17)</jdk>
+        <jdk>[9,16)</jdk>
       </activation>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <caffeine.version>2.6.2</caffeine.version>
     <protobuf.version>3.25.6</protobuf.version>
     <oss.driver.version>4.16.0</oss.driver.version>
-    <dsbulk.version>1.10.0</dsbulk.version>
+    <dsbulk.version>1.11.1</dsbulk.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <guava.version>25.1-jre</guava.version>
     <slf4j.version>1.7.36</slf4j.version>
@@ -459,7 +459,7 @@ limitations under the License.]]></inlineHeader>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
+          <version>0.8.14</version>
           <executions>
             <execution>
               <id>unit-tests-coverage</id>
@@ -665,7 +665,7 @@ limitations under the License.]]></inlineHeader>
           <plugins>
             <plugin>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.11.0</version>
+              <version>3.15.0</version>
               <configuration>
                 <source>${java.version}</source>
                 <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <guava.version>25.1-jre</guava.version>
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.13</logback.version>
-    <junit.version>5.4.1</junit.version>
+    <junit.version>5.10.2</junit.version>
     <assertj.version>3.14.0</assertj.version>
     <mockito.version>2.18.3</mockito.version>
     <wiremock.version>2.25.0</wiremock.version>
@@ -271,11 +271,6 @@
         <version>${confluent.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.confluent</groupId>
-        <artifactId>kafka-schema-registry-client-encryption-hcvault</artifactId>
-        <version>${confluent.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>
         <version>${amazonaws.version}</version>
@@ -464,7 +459,7 @@ limitations under the License.]]></inlineHeader>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.6</version>
+          <version>0.8.12</version>
           <executions>
             <execution>
               <id>unit-tests-coverage</id>
@@ -659,17 +654,54 @@ limitations under the License.]]></inlineHeader>
     </plugins>
   </build>
   <profiles>
+    <!-- NEW: Separate profile specifically for Java 21+ -->
     <profile>
-      <id>jdk11</id>
+      <id>jdk21</id>
       <activation>
-        <jdk>[9..)</jdk>
+        <jdk>21</jdk>
       </activation>
       <build>
         <pluginManagement>
           <plugins>
             <plugin>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.8.1</version>
+              <version>3.11.0</version>
+              <configuration>
+                <source>${java.version}</source>
+                <target>${java.version}</target>
+                <release>${java.release.version}</release>
+                <showDeprecation>true</showDeprecation>
+                <showWarnings>true</showWarnings>
+                <failOnWarning>false</failOnWarning>
+                <fork>false</fork>
+                <compilerArgs>
+                  <arg>-XDcompilePolicy=simple</arg>
+                  <arg>-Xplugin:ErrorProne</arg>
+                </compilerArgs>
+                <annotationProcessorPaths>
+                  <path>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>2.28.0</version>
+                  </path>
+                </annotationProcessorPaths>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[9,21)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.11.0</version>
               <configuration>
                 <source>${java.version}</source>
                 <target>${java.version}</target>
@@ -687,7 +719,7 @@ limitations under the License.]]></inlineHeader>
                   <path>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_core</artifactId>
-                    <version>2.4.0</version>
+                    <version>2.28.0</version>
                   </path>
                 </annotationProcessorPaths>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@ limitations under the License.]]></inlineHeader>
     <profile>
       <id>jdk21</id>
       <activation>
-        <jdk>21</jdk>
+        <jdk>[21..)</jdk>
       </activation>
       <build>
         <pluginManagement>

--- a/sink/pom.xml
+++ b/sink/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>kafka-schema-registry-client-encryption-hcvault</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.confluent</groupId>
-      <artifactId>kafka-schema-registry-client-encryption-hcvault</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/sink/src/it/java/com/datastax/oss/kafka/sink/state/LifeCycleManagerIT.java
+++ b/sink/src/it/java/com/datastax/oss/kafka/sink/state/LifeCycleManagerIT.java
@@ -93,9 +93,10 @@ class LifeCycleManagerIT {
       assertThat(set).isNotNull();
       // and endPoint uses unresolved DNS address
       EndPoint endPoint = getEndPoint(session);
-      assertThat(endPoint.toString())
-          .isEqualTo(String.format("%s:%d", contactPointDns, ccm.getBinaryPort()));
-      assertTrue(((InetSocketAddress) endPoint.resolve()).isUnresolved());
+      InetSocketAddress address = (InetSocketAddress) endPoint.resolve();
+      assertThat(address.getHostString()).isEqualTo(contactPointDns);
+      assertThat(address.getPort()).isEqualTo(ccm.getBinaryPort());
+      assertTrue(address.isUnresolved());
     }
   }
 
@@ -127,9 +128,10 @@ class LifeCycleManagerIT {
       assertThat(set).isNotNull();
       // and endPoint uses unresolved IP address
       EndPoint endPoint = getEndPoint(session);
-      assertThat(endPoint.toString())
-          .isEqualTo(String.format("%s:%d", contactPointIp, ccm.getBinaryPort()));
-      assertTrue(((InetSocketAddress) endPoint.resolve()).isUnresolved());
+      InetSocketAddress address = (InetSocketAddress) endPoint.resolve();
+      assertThat(address.getHostString()).isEqualTo(contactPointIp);
+      assertThat(address.getPort()).isEqualTo(ccm.getBinaryPort());
+      assertTrue(address.isUnresolved());
     }
   }
 

--- a/sink/src/main/java/com/datastax/oss/kafka/sink/CassandraSinkTask.java
+++ b/sink/src/main/java/com/datastax/oss/kafka/sink/CassandraSinkTask.java
@@ -105,7 +105,7 @@ public class CassandraSinkTask extends SinkTask {
     /**
      * Handle a failed record.
      *
-     * @param record the {@link SinkRecord} that failed to process
+     * @param abstractRecord the {@link SinkRecord} that failed to process
      * @param e the exception
      * @param cql the cql statement that failed to execute
      * @param failCounter the metric that keeps track of number of failures encountered


### PR DESCRIPTION
https://datastax.jira.com/browse/STREAM-822

JDK 16 introduced strong encapsulation of JDK internals (JEP 403), which prevents access to com.sun.tools.javac.* APIs used by Error Prone.
This results in IllegalAccessError during compilation.
To address this, we add --add-exports and --add-opens JVM flags to explicitly allow access to these internal APIs.

Reference:
JEP 403 (Strong Encapsulation): https://openjdk.org/jeps/403
Error Prone compatibility notes: https://errorprone.info/docs/installation

